### PR TITLE
[AJ-5305] Use prebuilt image with wkhtmltopdf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,8 +87,8 @@ jobs:
       - run:
           name: Build docker image and publish image tagged with commit
           command: |
-            docker build -t avvo/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1 .
             docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker build -t avvo/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1 .
             docker push avvo/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM elixir:1.8-alpine AS BOB_THE_BUILDER
 
-ARG MIX_ENV=prod
-
-ENV MIX_ENV=${MIX_ENV}
+ENV MIX_ENV=prod
 
 WORKDIR /opt/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,22 +24,13 @@ RUN mkdir -p /opt/app/built && \
 
 ## Now, build the actual release image
 
-FROM alpine:3.9
+FROM surnet/alpine-wkhtmltopdf:3.9-0.12.5-small
 
-RUN apk add --no-cache qt5-qtwebkit qt5-qtbase bash openssl
-
-RUN apk add \
-    --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \
-    --allow-untrusted \
-    --no-cache \
-    wkhtmltopdf
-
-RUN rm -f /var/cache/apk/*
+RUN apk add bash --no-cache
 
 RUN mkdir -p /opt/app/pdf_maker
 
 WORKDIR /opt/app/pdf_maker
-
 RUN WK_PATH=$(find / -name wkhtmltopdf) && \
     export PATH=$WK_PATH:$PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN mkdir -p /opt/app/built && \
 
 FROM avvo/alpine:3.9-wkhtmltopdf-0.12.5
 
+RUN apk add --no-cache bash
+
 RUN mkdir -p /opt/app/pdf_maker
 
 WORKDIR /opt/app/pdf_maker

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,15 +24,11 @@ RUN mkdir -p /opt/app/built && \
 
 ## Now, build the actual release image
 
-FROM surnet/alpine-wkhtmltopdf:3.9-0.12.5-small
-
-RUN apk add bash --no-cache
+FROM avvo/alpine:3.9-wkhtmltopdf-0.12.5
 
 RUN mkdir -p /opt/app/pdf_maker
 
 WORKDIR /opt/app/pdf_maker
-RUN WK_PATH=$(find / -name wkhtmltopdf) && \
-    export PATH=$WK_PATH:$PATH
 
 COPY --from=BOB_THE_BUILDER /opt/app/built/pdf_maker.tar.gz .
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -5,7 +5,7 @@ config :pdf_maker, PdfMakerWeb.Endpoint,
   secret_key_base: System.get_env("PDF_MAKER_KEY_BASE")
 
 config :pdf_generator,
-       wkhtml_path: "/usr/bin/wkhtmltopdf"
+  wkhtml_path: "/bin/wkhtmltopdf"
 
 config :phoenix, :serve_endpoints, true
 


### PR DESCRIPTION
## The Issue
https://jira.internetbrands.com/browse/AJ-5305
pdf-maker generates an empty file

## The solution

I compiled `Qt5` and `wkhtmltopdf` from sources on `alpine:3.9` and set it up to `avvo/alpine:3.9`. Now this image will always have the same compiled version of `wkhtmltopdf` with always same required dependencies that work.

## Why?
The problem was in system dependencies.. since we don't have analogous to `.lock` files, during the build alpine fetches currently available versions of packages listed in `apk add...` moreover we were pulling `wkhtmltopdf` from `edge` repo. I tried to fix it to alpine v3.9.. and then v3.10 (since 3.10 was active at the time of last building of correctly functioning package). As of today both of them are weirdly misfunctioning.. first solution was - to use setup `wkhtmltopdf` to ubuntu.. since official release comes with compiled binaries for ubuntu and we may assume that it's more stabile there than on alpine. But looks like compiled from sources on alpine also works fine.. and resulting image is 3 times smaller!

## How did I test it
I deployed this version to Staging - check it out:

```bash
curl -XPOST http://pdf-maker.staging.avvo.com/api/v1/html \
  -H 'content-type: application/json' \
  -d '{"html": "<h1>HELLO</h1><p>World</p>"}' \
  -o hello.pdf
```